### PR TITLE
Update docker-compose.yml file version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: "3.5"
 x-environment:
   &QUICKSTART_ENVIRONMENT # These are read from .env file. The values in the .env file maybe overriden by shell envvars
   PLAID_CLIENT_ID: ${PLAID_CLIENT_ID}


### PR DESCRIPTION
I was going to create an issue, but honestly a PR is just as easy as an issue.

in docker-compose.yml

```
network:
   xxxxxxxx:
      name: yyyyyyyyy
```

is not valid until file format 3.5

Before change:
```
└─ $ ▶ docker-compose -f docker-compose.yml config
ERROR: The Compose file './docker-compose.yml' is invalid because:
networks.quickstart value Additional properties are not allowed ('name' was unexpected)
````

After change:
```
└─ $ ▶ docker-compose -f docker-compose.yml config
networks:
  quickstart:
    name: quickstart
services:
[....]
version: '3.5'
````